### PR TITLE
Add license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "type": "library",
   "homepage": "https://github.com/optigov/php-cmis-client",
   "description": "A PHP CMIS client library",
+  "license": "MIT",
   "keywords": [],
   "require": {
     "php": ">=8.0",


### PR DESCRIPTION
So that it can be displayed on https://packagist.org/packages/optigov/php-cmis-client.