### PR TITLE
Set explicit utf-8 charset, see rfc5987 3.2

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -164,15 +164,39 @@ class Client
                     "contents" => $content
                 ];
             } else {
+                // send utf-8 encoded filename and ascii fallback filename
+                $asciiFilename = $this->getAsciiFilename($content["filename"]);
+                $filename = rawurlencode($content["filename"]);
                 $multipartData[] = [
                     "name" => $name,
                     "contents" => $content["content"],
+                    // used by guzzle to guess the mimetype
                     "filename" => $content["filename"],
+                    "headers" => ["Content-Disposition" => "form-data; name=\"$name\"; filename=\"$asciiFilename\"; filename*=UTF-8''$filename"],
                 ];
             }
         }
 
         return $this->httpClient->post($request->getUrl(), ["multipart" => $multipartData]);
+    }
+
+    /**
+     * Transliterates the filename to an ASCII fallback for the Content-Disposition Header
+     *
+     * @param string $filename
+     * @return string
+     */
+    private function getAsciiFilename(string $filename): string
+    {
+        if (function_exists('transliterator_transliterate')) {
+            $result = transliterator_transliterate('Any-Latin; Latin-ASCII', $filename);
+            if ($result !== false) {
+                $filename = $result;
+            }
+        }
+
+        // only keep ASCII chars
+        return preg_replace('/[^\x20-\x7E]/', '_', $filename);
     }
 
     /**

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -114,6 +114,11 @@ class Request
         // add post fields
         $postFields = $this->postFields;
 
+        // add UTF-8 _charset_ default charset indicator
+        if (!array_key_exists("_charset_", $postFields)) {
+            $postFields = ["_charset_" => "UTF-8"] + $postFields;
+        }
+
         // add properties
         $idx = 0;
         foreach ($this->properties as $id => $value) {

--- a/tests/Unit/Http/ClientTest.php
+++ b/tests/Unit/Http/ClientTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace CMIS\Tests\Unit\Http;
+
+use CMIS\Http\Client;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class ClientTest extends TestCase
+{
+    private function asciiFilename(string $filename): string
+    {
+        $method = new ReflectionMethod(Client::class, "getAsciiFilename");
+
+        return $method->invoke(new Client(), $filename);
+    }
+
+    public function testVerifyStringPathIsForwardedVerbatim(): void
+    {
+        $client = (new Client())
+            ->setOptions(["verify" => "/etc/ssl/ca.pem"])
+            ->initialize();
+
+        $this->assertSame("/etc/ssl/ca.pem", $client->getHttpClient()->getConfig("verify"));
+    }
+
+    public function testCurlOptionReachesGuzzleConfig(): void
+    {
+        $curl = [CURLOPT_RESOLVE => ["host:443:1.2.3.4"]];
+
+        $client = (new Client())
+            ->setOptions(["curl" => $curl])
+            ->initialize();
+
+        $this->assertSame($curl, $client->getHttpClient()->getConfig("curl"));
+    }
+
+    public function testBearerTokenSetsAuthorizationHeaderAndMergesCallerHeaders(): void
+    {
+        $client = (new Client())
+            ->setOptions(["headers" => ["X-Custom" => "value"]])
+            ->setAuth(null, null, "the-token")
+            ->initialize();
+
+        $headers = $client->getHttpClient()->getConfig("headers");
+
+        $this->assertSame("Bearer the-token", $headers["Authorization"]);
+        $this->assertSame("value", $headers["X-Custom"]);
+    }
+
+    public function testDefaultVerifyIsEnabled(): void
+    {
+        $client = (new Client())->initialize();
+
+        $this->assertTrue($client->getHttpClient()->getConfig("verify"));
+    }
+
+    public function testDeprecatedVerifySSLDisablesVerification(): void
+    {
+        $client = (new Client())->verifySSL(false)->initialize();
+
+        $this->assertFalse($client->getHttpClient()->getConfig("verify"));
+        $this->assertFalse($client->SSLisVerified());
+    }
+
+    // -------------------------------------------------------------------------
+    // getAsciiFilename (Content-Disposition ASCII fallback)
+    // -------------------------------------------------------------------------
+
+    public function testAsciiFilenamePassesPlainAsciiThroughUnchanged(): void
+    {
+        $this->assertSame("dokument.txt", $this->asciiFilename("dokument.txt"));
+    }
+
+    public function testAsciiFilenameResultContainsOnlyAsciiChars(): void
+    {
+        $result = $this->asciiFilename("Öffnungszeiten_Grüße.pdf");
+
+        $this->assertSame(1, preg_match('/^[\x20-\x7E]*$/', $result));
+    }
+
+    public function testAsciiFilenameTransliteratesGermanUmlauts(): void
+    {
+        if (!function_exists("transliterator_transliterate")) {
+            $this->markTestSkipped("intl extension not available");
+        }
+
+        $this->assertSame("Strasse_Grosse.pdf", $this->asciiFilename("Straße_Größe.pdf"));
+    }
+}

--- a/tests/Unit/Http/RequestTest.php
+++ b/tests/Unit/Http/RequestTest.php
@@ -43,6 +43,29 @@ class RequestTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // _charset_ indicator
+    // -------------------------------------------------------------------------
+
+    public function testCharsetDefaultsToUtf8(): void
+    {
+        $request = new Request('http://example.com');
+
+        $fields = $request->getMergedPostFields();
+
+        $this->assertSame('UTF-8', $fields['_charset_']);
+    }
+
+    public function testCharsetIsNotOverriddenWhenCallerSetsIt(): void
+    {
+        $request = new Request('http://example.com');
+        $request->addPostField('_charset_', 'ISO-8859-1');
+
+        $fields = $request->getMergedPostFields();
+
+        $this->assertSame('ISO-8859-1', $fields['_charset_']);
+    }
+
+    // -------------------------------------------------------------------------
     // Scalar properties
     // -------------------------------------------------------------------------
 

--- a/tests/Unit/Session/SessionOptionsTest.php
+++ b/tests/Unit/Session/SessionOptionsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace CMIS\Tests\Unit\Session;
+
+use CMIS\Session\SessionOptions;
+use PHPUnit\Framework\TestCase;
+
+class SessionOptionsTest extends TestCase
+{
+    public function testDefaultConstructorEnablesVerify(): void
+    {
+        $options = new SessionOptions();
+
+        $this->assertSame(["verify" => true], $options->getOptions());
+        $this->assertTrue($options->getOption("verify"));
+    }
+
+    public function testConstructorAcceptsCustomOptions(): void
+    {
+        $bag = [
+            "verify"  => "/path/to/ca.pem",
+            "curl"    => [CURLOPT_RESOLVE => ["host:443:1.2.3.4"]],
+            "timeout" => 12,
+        ];
+
+        $options = new SessionOptions($bag);
+
+        $this->assertSame($bag, $options->getOptions());
+    }
+
+    public function testSetOptionOverridesAndAdds(): void
+    {
+        $options = (new SessionOptions())
+            ->setOption("verify", false)
+            ->setOption("timeout", 5);
+
+        $this->assertFalse($options->getOption("verify"));
+        $this->assertSame(5, $options->getOption("timeout"));
+    }
+
+    public function testSetOptionAcceptsCaBundlePathString(): void
+    {
+        $options = (new SessionOptions())->setOption("verify", "/etc/ssl/ca.pem");
+
+        $this->assertSame("/etc/ssl/ca.pem", $options->getOption("verify"));
+    }
+
+    public function testGetOptionReturnsNullForMissingKey(): void
+    {
+        $this->assertNull((new SessionOptions())->getOption("does-not-exist"));
+    }
+}


### PR DESCRIPTION
Fixes encoding errors when filenames have UTF-8 chars. 

Also added missing test coverage for the guzzle options passthrough feature.